### PR TITLE
Add 'add_callback' and 'del_callback' methods.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ pip install mopidyapi
 
 `MopidyAPI` contains functions mapping to each of [the Mopidy v3.0.1 core API functions.](https://docs.mopidy.com/en/latest/api/core/)
 
-For example `mopidy.core.PlaybackController.pause()` in the documentation maps to `MopidyAPI.playback.pause()` here. 
+For example `mopidy.core.PlaybackController.pause()` in the documentation maps to `MopidyAPI.playback.pause()` here.
 
 ### Quick example
 
@@ -103,7 +103,28 @@ def print_newtracks(event):
 
 Like with function calls, the events passed are [namedtuples.](https://docs.python.org/3.7/library/collections.html#collections.namedtuple)
 
-An important caveat with the event listener decorators,
+Alternatively you can use `add_callback` and `del_callback`, which can also be used
+inside a class:
+```python
+from mopidyapi import MopidyAPI
+
+class Mopidy:
+
+    def __init__(self):
+        self.m = MopidyAPI()
+
+        m.add_callback('volume_changed', self.print_volume)
+        m.add_callback('track_playback_started', self.print_newtracks)
+
+    def print_volume(self, event):
+        print(f"Volume changed to: {event.volume}")
+
+    def print_newtracks(self, event):
+        print(f"Started playing track: {event.track.name}")
+
+```
+
+An important caveat with both the event listener decorators and add methods,
 is that it will not warn you in any way, if you use an invalid event name (e.g. you misspell the event name).
 
 ## Note on the choice of `namedtuples`
@@ -117,7 +138,7 @@ but they have a number of advantages over dictionaries for this application:
 
 `event.tl_track.track.album.name`
 
-is shorter and easier on the eyes than 
+is shorter and easier on the eyes than
 
 `event['tl_track']['track']['album']['name']`
 

--- a/mopidyapi/client.py
+++ b/mopidyapi/client.py
@@ -54,6 +54,8 @@ class MopidyAPI:
                                            logger=self.logger,
                                            flask_object=flask_object)
             self.on_event = self.wsclient.on_event
+            self.add_callback = self.wsclient.add_callback
+            self.del_callback = self.wsclient.del_callback
 
     def rpc_call(self, command: str, *args, **kwargs):
         """ Call the Mopidy HTTP JSON RPC API, (by sending

--- a/mopidyapi/parsedata.py
+++ b/mopidyapi/parsedata.py
@@ -15,9 +15,9 @@ def deserialize_mopidy(data):
     into an identical structure of namedtuples.
     """
     # first detect type of data
-    if isinstance(data, dict) and '__model__' in data.keys():
+    if isinstance(data, dict) and '__model__' in data:
         # define namedtuple based on keys in dict
-        fields = [k for k in data.keys() if k != '__model__']
+        fields = [k for k in data if k != '__model__']
         nt = namedtuple(data['__model__'], fields)
 
         # recurse on dict


### PR DESCRIPTION
I needed a method to add a callback from inside a class (see example in `README.md`).

At the same time I took the liberty to remove the `keys()` calls to dictionary, because they are not required (any more) (see https://docs.python.org/3/library/stdtypes.html#dict-views)