### PR TITLE
Catch all callback event "*"

### DIFF
--- a/mopidyapi/wsclient.py
+++ b/mopidyapi/wsclient.py
@@ -80,20 +80,21 @@ class MopidyWSClient:
         evname = event['event']
         self.logger.debug(f"Routing event: {evname}")
         callbacks = self._event_callbacks.get(evname, [])
-        for cb in callbacks:
+        if callbacks:
             # deserialize into neat named tuples
-            nt = namedtuple(evname, event.keys())
+            nt = namedtuple(evname, event)
             neatdata = nt(**{k: deserialize_mopidy(event[k]) for k in event})
 
-            # call the callback
-            if self.flask_object is not None:
-                # allow event handlers to use flask obj
-                # despite running in separate thread
-                with self.flask_object.app_context():
+            for cb in callbacks:
+                # call the callback
+                if self.flask_object is not None:
+                    # allow event handlers to use flask obj
+                    # despite running in separate thread
+                    with self.flask_object.app_context():
+                        cb(neatdata)
+                else:
+                    # regular callback (all cases but flask apps)
                     cb(neatdata)
-            else:
-                # regular callback (all cases but flask apps)
-                cb(neatdata)
 
     def on_event(self, event: str):
         """ Function decorator, to listen for events.

--- a/mopidyapi/wsclient.py
+++ b/mopidyapi/wsclient.py
@@ -79,7 +79,9 @@ class MopidyWSClient:
         """
         evname = event['event']
         self.logger.debug(f"Routing event: {evname}")
-        callbacks = self._event_callbacks.get(evname, [])
+        callbacks = (
+            self._event_callbacks.get(evname, set()) |
+            self._event_callbacks.get('*', set()))
         if callbacks:
             # deserialize into neat named tuples
             nt = namedtuple(evname, event)


### PR DESCRIPTION
I wanted to have a catch-all callback event, where the callback function is executed for all events. I named this event "*", but maybe another name is more suitable?

At the same time, I pulled the creation of the named tuple out of the loop, so that it is only created once per event (https://github.com/AsbjornOlling/mopidyapi/commit/bb8572708773c15040a4d810441eecde8d51bc10)