### PR TITLE
Unify parameters for 'MopidyAPI' and 'MopidyWSClient'.

### DIFF
--- a/mopidyapi/client.py
+++ b/mopidyapi/client.py
@@ -38,7 +38,6 @@ class MopidyAPI:
 
         # get rpc addresses
         self.http_url = f'http://{host}:{port}/mopidy/rpc'
-        self.ws_url = f'ws://{host}:{port}/mopidy/ws'
 
         # load controllers (which encapsulate rpc methods)
         self.history = history.HistoryController(self)
@@ -50,7 +49,7 @@ class MopidyAPI:
 
         if use_websocket:
             # start websocket connection, and borrow a decorator
-            self.wsclient = MopidyWSClient(ws_url=self.ws_url,
+            self.wsclient = MopidyWSClient(host=host, port=port,
                                            logger=self.logger,
                                            flask_object=flask_object)
             self.on_event = self.wsclient.on_event

--- a/mopidyapi/wsclient.py
+++ b/mopidyapi/wsclient.py
@@ -17,11 +17,11 @@ from .parsedata import deserialize_mopidy
 
 class MopidyWSClient:
     """ Mopidy Websocket API Client """
-    def __init__(self, ws_url='localhost:6680', logger=None,
+    def __init__(self, host='localhost', port=6680, logger=None,
                  flask_object=None):
         # typical, boring constructor stuff
         self.logger = logger if logger else logging.getLogger(__name__)
-        self.ws_url = ws_url
+        self.ws_url = f'ws://{host}:{port}/mopidy/ws'
         self._event_callbacks = {}
 
         if flask_object is not None:


### PR DESCRIPTION
I needed just the `MopidyWSClient` and noticed, that
1. the default value for the `ws_url` keyword did not work
2. the `MopidyWSClient` has a different call signature than `MopidyAPI`

so I corrected both in one go.